### PR TITLE
Add Flask-Login based authentication

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,15 @@
 import os
-from flask import Flask, render_template, request, redirect, url_for, session
+from flask import Flask, render_template, request, redirect, url_for, abort
 from flask_migrate import Migrate
-from models import db
+from flask_login import (
+    LoginManager,
+    login_user,
+    logout_user,
+    login_required,
+    current_user,
+)
+from werkzeug.security import generate_password_hash, check_password_hash
+from models import db, User
 
 app = Flask(__name__)
 app.secret_key = 'replace-with-a-secure-key'
@@ -13,6 +21,13 @@ app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 # Initialize extensions
 db.init_app(app)
 migrate = Migrate(app, db)
+login_manager = LoginManager(app)
+login_manager.login_view = 'signin'
+
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
 
 # Placeholder data for bill portions
 USER_BILLS = {
@@ -23,40 +38,69 @@ USER_BILLS = {
 
 @app.route('/')
 def index():
-    if 'username' in session:
+    if current_user.is_authenticated:
         return redirect(url_for('dashboard'))
     return redirect(url_for('signin'))
+
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    error = None
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        if not username or not password:
+            error = 'Username and password are required.'
+        elif User.query.filter_by(username=username).first():
+            error = 'Username already taken.'
+        else:
+            user = User(
+                username=username,
+                password_hash=generate_password_hash(password),
+                role='user',
+            )
+            db.session.add(user)
+            db.session.commit()
+            login_user(user)
+            return redirect(url_for('dashboard'))
+    return render_template('register.html', error=error)
 
 @app.route('/signin', methods=['GET', 'POST'])
 def signin():
     error = None
     if request.method == 'POST':
         username = request.form.get('username')
-        if username:
-            session['username'] = username
+        password = request.form.get('password')
+        user = User.query.filter_by(username=username).first()
+        if user and check_password_hash(user.password_hash, password):
+            login_user(user)
             return redirect(url_for('dashboard'))
-        else:
-            error = 'Please enter a username.'
+        error = 'Invalid username or password.'
     return render_template('signin.html', error=error)
 
 @app.route('/dashboard')
+@login_required
 def dashboard():
-    username = session.get('username')
-    if not username:
-        return redirect(url_for('signin'))
-    bill = USER_BILLS.get(username.lower(), 0.0)
-    return render_template('dashboard.html', username=username, bill=bill)
+    bill = USER_BILLS.get(current_user.username.lower(), 0.0)
+    return render_template('dashboard.html', bill=bill)
 
 @app.route('/profile')
+@login_required
 def profile():
-    username = session.get('username')
-    if not username:
-        return redirect(url_for('signin'))
-    return render_template('profile.html', username=username)
+    return render_template('profile.html')
+
+
+@app.route('/manage')
+@login_required
+def manage():
+    if current_user.role != 'manager':
+        return abort(403)
+    return render_template('manage.html')
 
 @app.route('/signout')
+@login_required
 def signout():
-    session.pop('username', None)
+    logout_user()
     return redirect(url_for('signin'))
 
 if __name__ == '__main__':

--- a/models.py
+++ b/models.py
@@ -1,16 +1,18 @@
 from datetime import datetime
 from flask_sqlalchemy import SQLAlchemy
+from flask_login import UserMixin
 
 # SQLAlchemy instance used across the application
 # It will be initialized in app.py
 
 db = SQLAlchemy()
 
-class User(db.Model):
+class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
     name = db.Column(db.String(120))
     email = db.Column(db.String(120), unique=True)
+    password_hash = db.Column(db.String(255))
     role = db.Column(db.String(50))
     auth_sub = db.Column(db.String(100))
     family_id = db.Column(db.Integer, db.ForeignKey('family.id'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Flask==3.0.2
 Flask-SQLAlchemy==3.1.1
 Flask-Migrate==4.0.4
 psycopg2-binary==2.9.9
+
+Flask-Login==0.6.3

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -6,7 +6,7 @@
 </head>
 <body>
     <h1>Dashboard</h1>
-    <p>Welcome, {{ username }}!</p>
+    <p>Welcome, {{ current_user.username }}!</p>
     <p>Your portion of the bill is: <strong>${{ '%.2f'|format(bill) }}</strong></p>
     <p><a href="{{ url_for('profile') }}">Profile</a> | <a href="{{ url_for('signout') }}">Sign Out</a></p>
 </body>

--- a/templates/manage.html
+++ b/templates/manage.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Manager Area</title>
+</head>
+<body>
+    <h1>Manager Dashboard</h1>
+    <p>This page is only visible to managers.</p>
+    <p><a href="{{ url_for('dashboard') }}">Back to Dashboard</a></p>
+</body>
+</html>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -6,7 +6,7 @@
 </head>
 <body>
     <h1>Profile</h1>
-    <p>Username: {{ username }}</p>
+    <p>Username: {{ current_user.username }}</p>
     <p><a href="{{ url_for('dashboard') }}">Dashboard</a> | <a href="{{ url_for('signout') }}">Sign Out</a></p>
 </body>
 </html>

--- a/templates/register.html
+++ b/templates/register.html
@@ -2,10 +2,10 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Sign In</title>
+    <title>Register</title>
 </head>
 <body>
-    <h1>Sign In</h1>
+    <h1>Register</h1>
     {% if error %}
     <p style="color:red;">{{ error }}</p>
     {% endif %}
@@ -16,8 +16,8 @@
         <label for="password">Password:</label>
         <input type="password" name="password" id="password" required>
         <br>
-        <button type="submit">Sign In</button>
+        <button type="submit">Register</button>
     </form>
-    <p>Don't have an account? <a href="{{ url_for('register') }}">Register</a></p>
+    <p>Already have an account? <a href="{{ url_for('signin') }}">Sign in</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- install Flask-Login
- add password hashing and role field support
- implement registration and login views
- require login for pages and restrict manager area

## Testing
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684357aa230483309a031f452a06e4c3