### PR TITLE
Add initial tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ The application will start on `http://localhost:5000/`.
 - `/profile` – Simple profile page showing the current username.
 
 This project uses in-memory placeholder data for demonstration purposes only.
+
+## Running Tests
+
+To run the automated test suite locally:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask==3.0.2
+pytest==8.2.0
+coverage==7.5.1

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,17 @@
+import pytest
+from app import app
+
+
+def test_signin_required():
+    tester = app.test_client()
+    response = tester.get('/dashboard', follow_redirects=False)
+    assert response.status_code == 302
+    assert '/signin' in response.headers['Location']
+
+
+def test_user_bill_display():
+    tester = app.test_client()
+    with tester:
+        tester.post('/signin', data={'username': 'alice'}, follow_redirects=True)
+        response = tester.get('/dashboard')
+        assert b"$20.50" in response.data

--- a/tests/test_bills.py
+++ b/tests/test_bills.py
@@ -1,0 +1,7 @@
+from app import USER_BILLS
+
+
+def test_bill_values():
+    assert USER_BILLS['alice'] == 20.50
+    assert USER_BILLS['bob'] == 35.00
+    assert USER_BILLS['charlie'] == 15.75


### PR DESCRIPTION
## Summary
- add pytest and coverage to requirements
- add test suite for authentication and bills
- run tests in CI workflow
- document running tests locally

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==3.0.2)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684352b4bff0833088e477d2257ddeed