### PR TITLE
Load SECRET_KEY from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for FamilyPhonePay
+# SECRET_KEY is used to secure sessions. Change the value in production.
+SECRET_KEY=dev-secret
+# DATABASE_URL=sqlite:///app.db

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ and includes instructions for running database migrations.
 pip install -r requirements.txt
 ```
 
-3. Set the `DATABASE_URL` environment variable if you do not want to use the
-   default SQLite database. Example for PostgreSQL:
+3. Copy `.env.example` to `.env` and adjust the values if needed. By default the
+   application uses `dev-secret` for `SECRET_KEY` and a SQLite database. To use
+   another database you can set `DATABASE_URL` in `.env`. Example for PostgreSQL:
 
 ```bash
-export DATABASE_URL=postgresql://user:password@localhost/dbname
+cp .env.example .env
+echo "DATABASE_URL=postgresql://user:password@localhost/dbname" >> .env
 ```
 
 4. Run database migrations (only required after the first setup or when models

--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from models import db, User
 
 app = Flask(__name__)
-app.secret_key = 'replace-with-a-secure-key'
+app.secret_key = os.getenv("SECRET_KEY", "dev-secret")
 
 # Database configuration
 app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DATABASE_URL', 'sqlite:///app.db')


### PR DESCRIPTION
## Summary
- use `os.getenv` to set Flask `secret_key`
- provide `.env.example` with `SECRET_KEY`
- update README with environment setup steps

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68435a72fa788330ae43545068a23e74