### PR TITLE
Add JSON API endpoints for bills

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,94 @@
+from datetime import datetime
+from flask import Blueprint, request, jsonify, abort
+from flask_login import login_required, current_user
+
+from models import db, Family, Bill, BillItem
+
+api_bp = Blueprint('api', __name__, url_prefix='/api')
+
+
+def manager_required():
+    if not current_user.is_authenticated or current_user.role != 'manager':
+        abort(403)
+
+
+@api_bp.route('/families', methods=['POST'])
+@login_required
+def create_family():
+    manager_required()
+    data = request.get_json() or {}
+    name = data.get('name')
+    if not name:
+        return jsonify({'error': 'Name required'}), 400
+    family = Family(name=name)
+    db.session.add(family)
+    db.session.commit()
+    return jsonify({'id': family.id, 'name': family.name}), 201
+
+
+@api_bp.route('/bills', methods=['POST'])
+@login_required
+def publish_bill():
+    manager_required()
+    data = request.get_json() or {}
+    family_id = data.get('family_id')
+    if not family_id:
+        return jsonify({'error': 'family_id required'}), 400
+    bill = Bill(
+        family_id=family_id,
+        created_by=current_user.id,
+        cycle_month=data.get('cycle_month'),
+        total_amount=data.get('total_amount'),
+        due_date=datetime.strptime(data['due_date'], '%Y-%m-%d').date() if data.get('due_date') else None,
+        published_at=datetime.utcnow(),
+    )
+    db.session.add(bill)
+    db.session.commit()
+    return jsonify({'id': bill.id}), 201
+
+
+@api_bp.route('/bills/<int:bill_id>/items', methods=['POST'])
+@login_required
+def add_surcharge(bill_id):
+    manager_required()
+    bill = Bill.query.get_or_404(bill_id)
+    data = request.get_json() or {}
+    description = data.get('description')
+    amount = data.get('amount')
+    if not description or amount is None:
+        return jsonify({'error': 'description and amount required'}), 400
+    item = BillItem(
+        bill_id=bill.id,
+        user_id=data.get('user_id'),
+        description=description,
+        amount=amount,
+        is_recurring=data.get('is_recurring', False),
+    )
+    db.session.add(item)
+    db.session.commit()
+    return jsonify({'id': item.id}), 201
+
+
+@api_bp.route('/bills/<int:bill_id>', methods=['GET'])
+@login_required
+def bill_info(bill_id):
+    bill = Bill.query.get_or_404(bill_id)
+    items = [
+        {
+            'id': item.id,
+            'description': item.description,
+            'amount': float(item.amount) if item.amount is not None else None,
+            'user_id': item.user_id,
+        }
+        for item in bill.items
+    ]
+    return jsonify(
+        {
+            'id': bill.id,
+            'family_id': bill.family_id,
+            'total_amount': float(bill.total_amount) if bill.total_amount is not None else None,
+            'due_date': bill.due_date.isoformat() if bill.due_date else None,
+            'items': items,
+        }
+    )
+

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from flask_login import (
 )
 from werkzeug.security import generate_password_hash, check_password_hash
 from models import db, User
+from api import api_bp
 
 app = Flask(__name__)
 app.secret_key = os.getenv("SECRET_KEY", "dev-secret")
@@ -23,6 +24,9 @@ db.init_app(app)
 migrate = Migrate(app, db)
 login_manager = LoginManager(app)
 login_manager.login_view = 'signin'
+
+
+app.register_blueprint(api_bp)
 
 
 @login_manager.user_loader

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,54 @@
+import os
+import json
+import pytest
+from werkzeug.security import generate_password_hash
+
+# set database to in-memory before importing app
+os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+
+import app
+from app import app as flask_app
+from models import db, User, Family, Bill, BillItem
+
+
+@pytest.fixture
+def client():
+    flask_app.config['TESTING'] = True
+    with flask_app.app_context():
+        db.create_all()
+        manager = User(
+            username='manager',
+            password_hash=generate_password_hash('pass'),
+            role='manager',
+        )
+        family = Family(name='Smith')
+        db.session.add_all([manager, family])
+        db.session.commit()
+        yield flask_app.test_client()
+        db.session.remove()
+        db.drop_all()
+
+
+def login(client):
+    return client.post('/signin', data={'username': 'manager', 'password': 'pass'}, follow_redirects=True)
+
+
+def test_get_bill_detail(client):
+    with flask_app.app_context():
+        manager = User.query.filter_by(username='manager').first()
+        family = Family.query.first()
+        bill = Bill(family_id=family.id, created_by=manager.id, total_amount=100)
+        db.session.add(bill)
+        db.session.commit()
+        bill_id = bill.id
+        db.session.add(BillItem(bill_id=bill_id, description='test item', amount=10))
+        db.session.commit()
+
+    login(client)
+    rv = client.get(f'/api/bills/{bill_id}')
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data['id'] == bill_id
+    assert len(data['items']) == 1
+    assert data['items'][0]['description'] == 'test item'
+


### PR DESCRIPTION
## Summary
- expose new `/api` endpoints for families, bills and surcharges
- register API blueprint in the app
- include unit test for bill details endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_68435b6c7df88330bada662ffadb38fc