### PR TITLE
Add mailer and notification feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@
 # SECRET_KEY is used to secure sessions. Change the value in production.
 SECRET_KEY=dev-secret
 # DATABASE_URL=sqlite:///app.db
+SENDGRID_API_KEY=
+EMAIL_FROM=

--- a/mailer.py
+++ b/mailer.py
@@ -1,0 +1,33 @@
+import os
+import json
+from urllib import request
+
+SENDGRID_API_URL = 'https://api.sendgrid.com/v3/mail/send'
+
+
+def send_email(to_email: str, subject: str, content: str) -> None:
+    """Send a simple email via SendGrid."""
+    api_key = os.getenv('SENDGRID_API_KEY')
+    from_email = os.getenv('EMAIL_FROM')
+    if not api_key or not from_email:
+        raise RuntimeError('Email settings not configured')
+
+    payload = {
+        "personalizations": [{"to": [{"email": to_email}]}],
+        "from": {"email": from_email},
+        "subject": subject,
+        "content": [{"type": "text/plain", "value": content}],
+    }
+    data = json.dumps(payload).encode('utf-8')
+    req = request.Request(
+        SENDGRID_API_URL,
+        data=data,
+        headers={
+            'Authorization': f'Bearer {api_key}',
+            'Content-Type': 'application/json',
+        },
+        method='POST',
+    )
+    # Perform request but ignore response content
+    with request.urlopen(req) as resp:
+        resp.read()


### PR DESCRIPTION
## Summary
- add SendGrid-powered mailer utility
- email family members and log notifications when bills are published
- expose `SENDGRID_API_KEY` and `EMAIL_FROM` settings
- test bill publishing triggers mail

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6843609089f48330aa5e1c3a8d4083d8