### PR TITLE
Add Makefile and document dev workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+FLASK_APP=app.py
+
+.PHONY: dev migrate
+
+dev:
+	flask run --debug
+
+migrate:
+	flask db upgrade

--- a/README.md
+++ b/README.md
@@ -24,18 +24,18 @@ echo "DATABASE_URL=postgresql://user:password@localhost/dbname" >> .env
 ```
 
 4. Run database migrations (only required after the first setup or when models
-   change):
+   change). Initialize the migration repository once with `flask db init`, then
+   use the provided make target to apply migrations:
 
 ```bash
 flask db init        # only once
-flask db migrate -m "Initial tables"
-flask db upgrade
+make migrate
 ```
 
-5. Run the application:
+5. Run the application using the make target:
 
 ```bash
-python app.py
+make dev
 ```
 
 The application will start on `http://localhost:5000/`.


### PR DESCRIPTION
## Summary
- introduce a simple `Makefile` with `dev` and `migrate` commands
- update README instructions to use the make targets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6843617886348330a58d712089209b10