### PR TITLE
Add Render deployment files

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bash -c "flask db upgrade && gunicorn -b 0.0.0.0:$PORT app:app"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ make dev
 
 The application will start on `http://localhost:5000/`.
 
+## Deploying to Render
+
+1. Ensure the following environment variables are set in your Render service:
+   `SECRET_KEY`, `DATABASE_URL`, `SENDGRID_API_KEY`, and `EMAIL_FROM`. You can
+   use `.env.example` as a reference.
+2. Add a Postgres database in Render and set `DATABASE_URL` accordingly.
+3. Render will use the `Procfile` to start the app. The included command runs
+   database migrations and then starts Gunicorn:
+
+   ```bash
+   web: bash -c "flask db upgrade && gunicorn -b 0.0.0.0:$PORT app:app"
+   ```
+
+   Gunicorn listens on the port provided by Render via the `$PORT` environment
+   variable.
+
 ## Pages
 
 - `/signin` – Sign in with a username.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ psycopg2-binary==2.9.9
 
 Flask-Login==0.6.3
 pytest==8.2.1
+gunicorn==21.2.0


### PR DESCRIPTION
## Summary
- add Gunicorn dependency
- add Procfile with migration and Gunicorn start command
- document Render deployment instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for werkzeug)*
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==3.0.2)*

------
https://chatgpt.com/codex/tasks/task_e_6843c5c65bc0833087ce0d7a7625d9fe