### PR TITLE
Add Bootstrap styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ their portion of a bill. It includes basic routes for signing in, viewing a dash
 and displaying a profile page. The application now uses SQLAlchemy for persistence
 and includes instructions for running database migrations.
 
+The interface is styled using the open source [Bootstrap](https://getbootstrap.com/) library, pulled in via CDN.
+
 ## Setup
 
 1. Install Python 3 and pip.

--- a/static/style.css
+++ b/static/style.css
@@ -1,8 +1,3 @@
 body { font-family: Arial, sans-serif; margin: 0; padding: 0; background-color: #f4f4f4; }
-.container { width: 90%; max-width: 600px; margin: 40px auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+.page-container { width: 90%; max-width: 600px; margin: 40px auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 h1 { margin-top: 0; }
-nav { background: #333; color: #fff; padding: 10px; }
-nav a { color: #fff; margin-right: 10px; text-decoration: none; }
-button { padding: 5px 10px; }
-form label { display: block; margin-top: 10px; }
-input { padding: 5px; width: 100%; box-sizing: border-box; }

--- a/templates/accept_invite.html
+++ b/templates/accept_invite.html
@@ -3,14 +3,18 @@
 {% block content %}
 <h1>Accept Invitation</h1>
 {% if error %}
-<p style="color:red;">{{ error }}</p>
+<div class="alert alert-danger">{{ error }}</div>
 {% endif %}
 <form method="post">
     <p>Email: {{ email }}</p>
-    <label for="username">Username:</label>
-    <input type="text" name="username" id="username" required>
-    <label for="password">Password:</label>
-    <input type="password" name="password" id="password" required>
-    <button type="submit">Create Account</button>
+    <div class="mb-3">
+        <label for="username" class="form-label">Username:</label>
+        <input type="text" class="form-control" name="username" id="username" required>
+    </div>
+    <div class="mb-3">
+        <label for="password" class="form-label">Password:</label>
+        <input type="password" class="form-control" name="password" id="password" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Create Account</button>
 </form>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,21 +3,28 @@
 <head>
     <meta charset="utf-8">
     <title>{% block title %}{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
-    <nav>
-        {% if current_user.is_authenticated %}
-            <a href="{{ url_for('dashboard') }}">Dashboard</a>
-            <a href="{{ url_for('profile') }}">Profile</a>
-            <a href="{{ url_for('signout') }}">Sign Out</a>
-        {% else %}
-            <a href="{{ url_for('signin') }}">Sign In</a>
-            <a href="{{ url_for('register') }}">Register</a>
-        {% endif %}
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="{{ url_for('dashboard') }}">FamilyPhonePay</a>
+            <ul class="navbar-nav ms-auto">
+                {% if current_user.is_authenticated %}
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard') }}">Dashboard</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('profile') }}">Profile</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('signout') }}">Sign Out</a></li>
+                {% else %}
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('signin') }}">Sign In</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('register') }}">Register</a></li>
+                {% endif %}
+            </ul>
+        </div>
     </nav>
-    <div class="container">
+    <div class="page-container">
         {% block content %}{% endblock %}
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1>Dashboard</h1>
 <p>Welcome, {{ current_user.username }}!</p>
-<p>Your portion of the bill is: <strong id="bill-amount">${{ '%.2f'|format(bill) }}</strong></p>
+<p>Your portion of the bill is: <span class="fw-bold" id="bill-amount">${{ '%.2f'|format(bill) }}</span></p>
 <script>
 const evt = new EventSource("{{ url_for('sse_events') }}");
 evt.onmessage = function(e) {

--- a/templates/manage.html
+++ b/templates/manage.html
@@ -3,5 +3,5 @@
 {% block content %}
 <h1>Manager Dashboard</h1>
 <p>This page is only visible to managers.</p>
-<p><a href="{{ url_for('dashboard') }}">Back to Dashboard</a></p>
+<p><a class="btn btn-secondary" href="{{ url_for('dashboard') }}">Back to Dashboard</a></p>
 {% endblock %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -2,5 +2,5 @@
 {% block title %}Profile{% endblock %}
 {% block content %}
 <h1>Profile</h1>
-<p>Username: {{ current_user.username }}</p>
+<p><span class="fw-bold">Username:</span> {{ current_user.username }}</p>
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -3,14 +3,18 @@
 {% block content %}
 <h1>Register</h1>
 {% if error %}
-<p style="color:red;">{{ error }}</p>
+<div class="alert alert-danger">{{ error }}</div>
 {% endif %}
 <form method="post">
-    <label for="username">Username:</label>
-    <input type="text" name="username" id="username" required>
-    <label for="password">Password:</label>
-    <input type="password" name="password" id="password" required>
-    <button type="submit">Register</button>
+    <div class="mb-3">
+        <label for="username" class="form-label">Username:</label>
+        <input type="text" class="form-control" name="username" id="username" required>
+    </div>
+    <div class="mb-3">
+        <label for="password" class="form-label">Password:</label>
+        <input type="password" class="form-control" name="password" id="password" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Register</button>
 </form>
-<p>Already have an account? <a href="{{ url_for('signin') }}">Sign in</a></p>
+<p class="mt-3">Already have an account? <a href="{{ url_for('signin') }}">Sign in</a></p>
 {% endblock %}

--- a/templates/signin.html
+++ b/templates/signin.html
@@ -3,14 +3,18 @@
 {% block content %}
 <h1>Sign In</h1>
 {% if error %}
-<p style="color:red;">{{ error }}</p>
+<div class="alert alert-danger">{{ error }}</div>
 {% endif %}
 <form method="post">
-    <label for="username">Username:</label>
-    <input type="text" name="username" id="username" required>
-    <label for="password">Password:</label>
-    <input type="password" name="password" id="password" required>
-    <button type="submit">Sign In</button>
+    <div class="mb-3">
+        <label for="username" class="form-label">Username:</label>
+        <input type="text" class="form-control" name="username" id="username" required>
+    </div>
+    <div class="mb-3">
+        <label for="password" class="form-label">Password:</label>
+        <input type="password" class="form-control" name="password" id="password" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Sign In</button>
 </form>
-<p>Don't have an account? <a href="{{ url_for('register') }}">Register</a></p>
+<p class="mt-3">Don't have an account? <a href="{{ url_for('register') }}">Register</a></p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- bring in Bootstrap via CDN and restructure base template
- convert sign in, registration, and invite forms to Bootstrap
- tweak dashboard, profile, and manager views
- adjust custom stylesheet for new `.page-container`
- document that the UI uses Bootstrap

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for werkzeug)*

------
https://chatgpt.com/codex/tasks/task_e_684447ba4e14833099141260e6f0e81e