### PR TITLE
Graceful handling for Add Item access

### DIFF
--- a/app.py
+++ b/app.py
@@ -165,7 +165,7 @@ def profile():
 @login_required
 def add_item():
     if not current_user.family_id:
-        abort(400)
+        abort(400, description="You must belong to a family to add items.")
     family = Family.query.get(current_user.family_id)
     members = family.members
     error = None
@@ -235,6 +235,10 @@ def manage():
 def signout():
     logout_user()
     return redirect(url_for('signin'))
+
+@app.errorhandler(400)
+def handle_bad_request(e):
+    return render_template("400.html", message=getattr(e, "description", "Bad Request")), 400
 
 @app.route('/run-migrations')
 def run_migrations():

--- a/templates/400.html
+++ b/templates/400.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Bad Request{% endblock %}
+{% block content %}
+<h1 class="text-danger">Bad Request</h1>
+<p>{{ message }}</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a template to render 400 errors
- provide a friendly message when a user without a family accesses `/add-item`
- register a 400 error handler so the new page is used

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6844ba4ba95c833080798c1b0897d5d7